### PR TITLE
restoring the ability to run build

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+/*eslint-disable import/default */
+
 import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';


### PR DESCRIPTION
the comment "/*eslint-disable import/default */" must be added to index.js file , otherwise it prevents "npm run build" command from create production bundle